### PR TITLE
Bump pyth-client to v2.10.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/pythfoundation/pyth-client:devnet-v2.10.0
+FROM docker.io/pythfoundation/pyth-client:devnet-v2.10.1
 
 COPY main.py .
 


### PR DESCRIPTION
To keep the testing environment in line with what's running in devnet.