### PR TITLE
Bump and deploy rust program

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/pythfoundation/pyth-client:devnet-v2.10.1
+FROM docker.io/pythfoundation/pyth-client:pythd-v2.14.0
 
 COPY main.py .
 

--- a/main.py
+++ b/main.py
@@ -58,7 +58,7 @@ def main():
     logging.debug('Deploying program')
     deploy_output = check_output([
         'solana', 'program', 'deploy',
-        os.path.join(PYTH_CLIENT_PATH, 'target', 'oracle.so'),
+        os.path.join(PYTH_CLIENT_PATH, 'target', 'deploy', 'pyth_oracle.so'),
         '--commitment', 'finalized',
         '--url', 'localhost',
         '--keypair', keypair_path,


### PR DESCRIPTION
As we migrate to the rust entrypoint, the path of the program binary gets updated. Also bumping to the newest docker.